### PR TITLE
Calculate speed always as km/h

### DIFF
--- a/fvh3t/core/trajectory.py
+++ b/fvh3t/core/trajectory.py
@@ -73,15 +73,15 @@ class Trajectory:
         total_distance = 0.0
         total_time = 0
         max_speed = 0.0
-        
+
         da = QgsDistanceArea()
-        
+
         if self.__layer is not None:
             da.setSourceCrs(self.__layer.crs(), QgsCoordinateTransformContext())
         else:
             da.setSourceCrs(QgsCoordinateReferenceSystem("EPSG:3067"), QgsCoordinateTransformContext())
-            
-        convert: bool = da.lengthUnits() != QgsUnitTypes.DistanceUnit.DistanceMeteres
+
+        convert: bool = da.lengthUnits() != QgsUnitTypes.DistanceUnit.DistanceMeters
 
         for i in range(1, len(self.__nodes)):
             current_node = self.__nodes[i]
@@ -90,13 +90,13 @@ class Trajectory:
             distance = da.measureLine(current_node.point, previous_node.point)
             if convert:
                 distance = da.convertLengthMeasurement(distance, QgsUnitTypes.DistanceUnit.DistanceMeters)
-            
+
             time_difference = current_node.timestamp - previous_node.timestamp
             speed = distance / time_difference
-            
+
             if speed > max_speed:
                 max_speed = speed
-                
+
             total_distance += distance
             total_time += time_difference
 
@@ -106,7 +106,7 @@ class Trajectory:
         # here the max speed is in meters / millisecond
         # convert to km/h
         _, _, max_speed = self._movement_core()
-        
+
         max_speed = max_speed * 3600
         return round(max_speed, 2)
 
@@ -291,7 +291,6 @@ class TrajectoryLayer:
                     # TODO: this means we're storing timestamps as milliseconds
                     # We might want to use datetime or maybe convert to seconds?
                     timestamp = timestamp * 1000
-
 
                 nodes.append(TrajectoryNode(point, timestamp, width, length, height))
 

--- a/tests/core/test_trajectory.py
+++ b/tests/core/test_trajectory.py
@@ -20,7 +20,9 @@ def test_trajectory_intersects_gate(two_node_trajectory):
 
 
 def test_trajectory_layer_create_trajectories(qgis_point_layer):
-    traj_layer = TrajectoryLayer(qgis_point_layer, "id", "timestamp", "width", "length", "height", QgsUnitTypes.TemporalUnit.TemporalMilliseconds)
+    traj_layer = TrajectoryLayer(
+        qgis_point_layer, "id", "timestamp", "width", "length", "height", QgsUnitTypes.TemporalUnit.TemporalMilliseconds
+    )
     traj_layer.create_trajectories()
 
     trajectories: tuple[Trajectory, ...] = traj_layer.trajectories()
@@ -48,7 +50,9 @@ def test_trajectory_layer_create_trajectories(qgis_point_layer):
 
 
 def test_trajectory_layer_create_line_layer(qgis_point_layer):
-    traj_layer = TrajectoryLayer(qgis_point_layer, "id", "timestamp", "width", "length", "height", QgsUnitTypes.TemporalUnit.TemporalMilliseconds)
+    traj_layer = TrajectoryLayer(
+        qgis_point_layer, "id", "timestamp", "width", "length", "height", QgsUnitTypes.TemporalUnit.TemporalMilliseconds
+    )
     traj_layer.create_trajectories()
 
     line_layer = traj_layer.as_line_layer()
@@ -62,12 +66,20 @@ def test_trajectory_layer_create_line_layer(qgis_point_layer):
     assert feat1.geometry().asWkt() == "LineString (0 0, 1 0, 2 0)"
     assert feat2.geometry().asWkt() == "LineString (5 1, 5 2, 5 3)"
 
-    assert feat1.attribute("average_speed") == 3.6
-    assert feat2.attribute("average_speed") == 3.6
+    assert feat1.attribute("average_speed") == 36.0
+    assert feat2.attribute("average_speed") == 36.0
 
 
 def test_trajectory_layer_node_ordering(qgis_point_layer_non_ordered):
-    traj_layer = TrajectoryLayer(qgis_point_layer_non_ordered, "id", "timestamp", "width", "length", "height", QgsUnitTypes.TemporalUnit.TemporalMilliseconds)
+    traj_layer = TrajectoryLayer(
+        qgis_point_layer_non_ordered,
+        "id",
+        "timestamp",
+        "width",
+        "length",
+        "height",
+        QgsUnitTypes.TemporalUnit.TemporalMilliseconds,
+    )
     traj_layer.create_trajectories()
 
     trajectories = traj_layer.trajectories()
@@ -84,15 +96,12 @@ def test_trajectory_layer_node_ordering(qgis_point_layer_non_ordered):
 
 
 def test_trajectory_average_speed(two_node_trajectory: Trajectory, three_node_trajectory: Trajectory):
-    assert two_node_trajectory.average_speed() == 3.6
-    assert three_node_trajectory.average_speed() == 3.6
+    assert two_node_trajectory.average_speed() == 36.0
+    assert three_node_trajectory.average_speed() == 36.0
+
 
 def test_trajectory_maximum_speed(accelerating_three_node_trajectory: Trajectory):
-    assert accelerating_three_node_trajectory.maximum_speed() == 0.03
-
-
-def test_trajectory_average_speed(three_node_trajectory: Trajectory):
-    assert three_node_trajectory.average_speed() == 0.01
+    assert accelerating_three_node_trajectory.maximum_speed() == 96.0
 
 
 def test_trajectory_length(three_node_trajectory: Trajectory):


### PR DESCRIPTION
* timestamps are stored in milliseconds in the actual `TrajectoryNodes`:
* you can set a unit explicitly for a `TrajectoryLayer` in the constructor
* if it isn't given we try to infer it
* if the unit is seconds when the trajectories are created from a layer they are converted to milliseconds
* use `QgsDistanceArea` to calculate distances
  * this way we can convert the distances to meters

Fixes #13 