### PR TITLE
Enforce field types

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,39 @@ def qgis_point_layer_no_additional_fields():
 
 
 @pytest.fixture
+def qgis_point_layer_wrong_type():
+    layer = QgsVectorLayer("Point?crs=EPSG:3067", "Point Layer", "memory")
+
+    layer.startEditing()
+
+    layer.addAttribute(QgsField("id", QVariant.Int))
+    layer.addAttribute(QgsField("timestamp", QVariant.String))
+    layer.addAttribute(QgsField("width", QVariant.Int))
+    layer.addAttribute(QgsField("length", QVariant.Int))
+    layer.addAttribute(QgsField("height", QVariant.Int))
+
+    traj1_f1 = QgsFeature(layer.fields())
+    traj1_f1.setAttributes([1, 3000, 1, 1, 1])
+    traj1_f1.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(0, 0)))
+
+    traj1_f2 = QgsFeature(layer.fields())
+    traj1_f2.setAttributes([1, 6000, 1, 1, 1])
+    traj1_f2.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(1, 0)))
+
+    traj1_f3 = QgsFeature(layer.fields())
+    traj1_f3.setAttributes([1, 1000, 1, 1, 1])
+    traj1_f3.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(2, 0)))
+
+    layer.addFeature(traj1_f1)
+    layer.addFeature(traj1_f2)
+    layer.addFeature(traj1_f3)
+
+    layer.commitChanges()
+
+    return layer
+
+
+@pytest.fixture
 def qgis_point_layer_for_gate_count():
     layer = QgsVectorLayer("Point?crs=EPSG:3067", "Point Layer", "memory")
 
@@ -315,6 +348,34 @@ def qgis_gate_line_layer():
     layer.addFeature(gate1)
     layer.addFeature(gate2)
     layer.addFeature(gate3)
+
+    layer.commitChanges()
+
+    return layer
+
+
+@pytest.fixture
+def qgis_gate_line_layer_wrong_field_type():
+    layer = QgsVectorLayer("LineString?crs=EPSG:3067", "Line Layer", "memory")
+
+    layer.startEditing()
+
+    layer.addAttribute(QgsField("counts_left", QVariant.Bool))
+    layer.addAttribute(QgsField("counts_right", QVariant.Int))
+
+    gate = QgsFeature(layer.fields())
+    gate.setAttributes([True, True])
+    gate.setGeometry(
+        QgsGeometry.fromPolylineXY(
+            [
+                QgsPointXY(0, 0),
+                QgsPointXY(0, 1),
+                QgsPointXY(0, 2),
+            ]
+        )
+    )
+
+    layer.addFeature(gate)
 
     layer.commitChanges()
 

--- a/tests/core/test_gate_layer.py
+++ b/tests/core/test_gate_layer.py
@@ -1,3 +1,6 @@
+import pytest
+
+from fvh3t.core.exceptions import InvalidLayerException
 from fvh3t.core.gate_layer import GateLayer
 
 
@@ -32,3 +35,19 @@ def test_gate_layer_create_gates(qgis_gate_line_layer):
     assert len(gate1.segments()) == 2
     assert len(gate2.segments()) == 1
     assert len(gate3.segments()) == 4
+
+
+def test_is_field_valid(qgis_gate_line_layer, qgis_gate_line_layer_wrong_field_type):
+    with pytest.raises(InvalidLayerException, match="Counts left field either not found or of incorrect type."):
+        GateLayer(
+            qgis_gate_line_layer,
+            "count_right",  # use wrong field names on purpose
+            "count_left",
+        )
+
+    with pytest.raises(InvalidLayerException, match="Counts right field either not found or of incorrect type."):
+        GateLayer(
+            qgis_gate_line_layer_wrong_field_type,
+            "counts_left",
+            "counts_right",
+        )

--- a/tests/core/test_trajectory_layer.py
+++ b/tests/core/test_trajectory_layer.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 from qgis.core import QgsUnitTypes
 
+from fvh3t.core.exceptions import InvalidLayerException
 from fvh3t.core.trajectory_layer import TrajectoryLayer
 
 if TYPE_CHECKING:
@@ -83,7 +84,7 @@ def test_trajectory_layer_node_ordering(qgis_point_layer_non_ordered):
 
 
 def test_is_valid_is_layer_valid(qgis_vector_layer):
-    with pytest.raises(ValueError, match="Layer is not valid."):
+    with pytest.raises(InvalidLayerException, match="Layer is not valid."):
         TrajectoryLayer(
             qgis_vector_layer,
             "id",
@@ -96,7 +97,7 @@ def test_is_valid_is_layer_valid(qgis_vector_layer):
 
 
 def test_is_valid_is_point_layer(qgis_line_layer):
-    with pytest.raises(ValueError, match="Layer is not a point layer."):
+    with pytest.raises(InvalidLayerException, match="Layer is not a point layer."):
         TrajectoryLayer(
             qgis_line_layer,
             "id",
@@ -109,7 +110,7 @@ def test_is_valid_is_point_layer(qgis_line_layer):
 
 
 def test_is_valid_has_features(qgis_point_layer_no_features):
-    with pytest.raises(ValueError, match="Layer has no features."):
+    with pytest.raises(InvalidLayerException, match="Layer has no features."):
         TrajectoryLayer(
             qgis_point_layer_no_features,
             "id",
@@ -121,10 +122,21 @@ def test_is_valid_has_features(qgis_point_layer_no_features):
         )
 
 
-def test_is_valid_id_field_exists(qgis_point_layer_no_additional_fields):
-    with pytest.raises(ValueError, match="Id field not found in the layer."):
+def test_is_field_valid(qgis_point_layer_no_additional_fields, qgis_point_layer_wrong_type):
+    with pytest.raises(InvalidLayerException, match="Id field either not found or of incorrect type."):
         TrajectoryLayer(
             qgis_point_layer_no_additional_fields,
+            "id",
+            "timestamp",
+            "width",
+            "length",
+            "height",
+            QgsUnitTypes.TemporalUnit.TemporalMilliseconds,
+        )
+
+    with pytest.raises(InvalidLayerException, match="Timestamp field either not found or of incorrect type."):
+        TrajectoryLayer(
+            qgis_point_layer_wrong_type,
             "id",
             "timestamp",
             "width",


### PR DESCRIPTION
Fixes #28 

- Add a function `is_field_valid` to GateLayer and TrajectoryLayer
- Check that the field is of an accepted type
- Change to using an `InvalidLayerException` instead of a ValueError
  - Made more sense to use this since we're using custom exceptions for other stuff already